### PR TITLE
fix: Remove `set-output` ahead of deprecation.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,4 @@ output=$(curl -H "Content-Type: application/json" \
                 --data '{ "number": '"$2"' }' \
                 https://public.ecologi.com/impact/trees)
 
-echo "::set-output name=response::$output"
+echo "response=$output" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Changes Summary

Warning message on runs of this action link to the [deprecation notification](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), this PR updates the `entrypoint.sh` following the guidance in that changelog post to support the recommended method going forward.